### PR TITLE
Disable libssh2 usage

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,6 +14,7 @@ cmake(
         "BUILD_TESTING": "OFF",
         "CMAKE_USE_OPENSSL": "FALSE",
         "CURL_DISABLE_LDAP" : "TRUE",
+        "CURL_USE_LIBSSH2" : "FALSE",
     },
     defines = select({
         "@bazel_tools//src/conditions:windows": ["CURL_STATICLIB"],
@@ -52,6 +53,7 @@ cmake(
         "CMAKE_USE_OPENSSL": "TRUE",
         "CURL_DISABLE_LDAP" : "TRUE",
         "OPENSSL_ROOT_DIR": "$$EXT_BUILD_DEPS$$/openssl",
+        "CURL_USE_LIBSSH2" : "FALSE",
     },
     defines = select({
         "@bazel_tools//src/conditions:windows": ["CURL_STATICLIB"],

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ def deps():
 
 | curl | Copy `bazel/repos.bzl` from: |
 | :---: | :--------------------------: |
-| 7.78.0 | [7cf883b](https://github.com/3rdparty/bazel-rules-curl/tree/7cf883b56673808156d5d986818017901108e8d7) |
+| 7.78.0 | [d790072](https://github.com/3rdparty/bazel-rules-curl/tree/d790072956f942ff0d66f14692c1ce70038da133) |

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -33,7 +33,7 @@ def repos(external = True, repo_mapping = {}):
             git_repository,
             name = "com_github_3rdparty_bazel_rules_curl",
             remote = "https://github.com/3rdparty/bazel-rules-curl",
-            commit = "589c72943a70eb7a0ee123969015f1a6deacf316",
-            shallow_since = "1632331010 +0300",
+            commit = "50d2df5ac8688f01486ca5ef83835e8dc0e07ad8",
+            shallow_since = "1632600453 +0300",
             repo_mapping = repo_mapping,
         )


### PR DESCRIPTION
Using libcurl on MacOS machines crashes the program due to inability to load certain libssh2 symbols. libssh2 provides SCP and SFTP support for libcurl.